### PR TITLE
Response parsing fix

### DIFF
--- a/aweber_api/curl_response.php
+++ b/aweber_api/curl_response.php
@@ -1,43 +1,23 @@
 <?php
 
-# CurlResponse
-#
-# Author  Sean Huber - shuber@huberry.com
-# Date    May 2008
-#
-# A basic CURL wrapper for PHP
-#
-# See the README for documentation/examples or http://php.net/curl for more information
-# about the libcurl extension for PHP -- http://github.com/shuber/curl/tree/master
-#
+use PTS\ParserPsr7\Factory\Psr7Factory;
 
 class CurlResponse
 {
     public $body = '';
-    public $headers = array();
+    public $headers = [];
 
-    public function __construct($response)
+    public function __construct($httpMessage)
     {
-        # Extract headers from response
-        $pattern = '#HTTP/\d\.\d.*?$.*?\r\n\r\n#ims';
-        preg_match_all($pattern, $response, $matches);
-        $headers = explode("\r\n", str_replace("\r\n\r\n", '', array_pop($matches[0])));
+        $factory = new Psr7Factory;
+        $response = $factory->toPsr7Response($httpMessage);
 
-        # Extract the version and status from the first header
-        $version_and_status = array_shift($headers);
-        preg_match('#HTTP/(\d\.\d)\s(\d\d\d)\s(.*)#', $version_and_status, $matches);
-        $this->headers['Http-Version'] = $matches[1];
-        $this->headers['Status-Code'] = $matches[2];
-        $this->headers['Status'] = $matches[2].' '.$matches[3];
+        $this->headers = $response->getHeaders();
+        $this->headers['Http-Version'] = $response->getProtocolVersion();
+        $this->headers['Status-Code'] = $response->getStatusCode();
+        $this->headers['Status'] = $response->getReasonPhrase();
 
-        # Convert headers into an associative array
-        foreach ($headers as $header) {
-            preg_match('#(.*?)\:\s(.*)#', $header, $matches);
-            $this->headers[$matches[1]] = $matches[2];
-        }
-
-        # Remove the headers from the response body
-        $this->body = preg_replace($pattern, '', $response);
+        $this->body = $response->getBody();
     }
 
     public function __toString()
@@ -45,7 +25,8 @@ class CurlResponse
         return $this->body;
     }
 
-    public function headers(){
+    public function headers()
+    {
         return $this->headers;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
       "aweber_api/"
     ]
   },
+  "require": {
+    "alexpts/http-message-parser": "^0.0.3"
+  },
   "require-dev": {
     "phpdocumentor/phpdocumentor": "^2.9",
     "pdepend/pdepend": "^2.2",


### PR DESCRIPTION
Completely changed approach to parsing HTTP response as the original one relying heavily on custom regular expressions suddenly started failing due to some changes to response format on AWeber's end after many years of flawless operation.

Switched to https://github.com/alexpts/php-http-message-parser that extracts required headers and body for us.